### PR TITLE
Changed variable name so it doesn't contain 'AWS'

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -14,7 +14,7 @@
 <script>
 //<![CDATA[
 var map = L.map('map').setView([42.35139, -71.06593], 14);
-L.tileLayer('https://mbta-map-tiles-dev.s3.amazonaws.com/{z}/{x}/{y}.png', {
+L.tileLayer('https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 }).addTo(map);
 var hash = L.hash(map)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,6 +23,7 @@ if [ "$1" == "tiles" ]; then
     sudo -E -u postgres /var/lib/postgresql/src/generate_tiles.py
     if [ -n "${MAPNIK_TILE_S3_BUCKET}" ]; then
         cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/" --size-only
+        echo "AWS S3 sync has completed successfully"
     fi
 fi
 

--- a/etc/generate_tiles.py
+++ b/etc/generate_tiles.py
@@ -221,14 +221,14 @@ if __name__ == "__main__":
         tile_dir = tile_dir + '/'
 
     try: 
-        thread_count = int(os.environ['AWS_BATCH_JOB_COUNT'])
+        thread_count = int(os.environ['BATCH_JOB_COUNT'])
         current_thread = int(os.environ['AWS_BATCH_JOB_ARRAY_INDEX'])
         bbox = slice_map(thread_count, current_thread)
     except KeyError:
         print "WARN: AWS Batch variables were not set, running in single-threaded mode"
         bbox = slice_map(thread_count=1, current_thread=0)
     except ValueError, t:
-        print "ERROR: Uable to parse AWS Batch variables"
+        print "ERROR: Unable to parse AWS Batch variables"
         raise ValueError(t)
 
     render_tiles(bbox, mapfile, tile_dir, 1, 18, "MBTA", 4)

--- a/prod.html
+++ b/prod.html
@@ -14,7 +14,7 @@
 <script>
 //<![CDATA[
 var map = L.map('map').setView([42.35139, -71.06593], 14);
-L.tileLayer('https://mbta-map-tiles.s3.amazonaws.com/{z}/{x}/{y}.png', {
+L.tileLayer('https://mbta-map-tiles.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 }).addTo(map);
 var hash = L.hash(map)


### PR DESCRIPTION
Ticket: [Parallelize tile generation](https://app.asana.com/0/810933294009540/1118874771957262)

After close examination of yesterday's logs it became clear that parallel execution didn't work as intended and each of the 4 jobs has completed the full cycle instead of rendering the partial map. Apparently AWS doesn't like environment variables, which have "AWS" in their names. Changing it here along with few other minor fixes.