### PR TITLE
Adding flag, which controls S3 sync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,14 @@ $ docker run --tty \
 
 ### Build & Publish Tiles
 
-To generate all tile images at once, append `tiles` to the `docker run` command. You can also upload them directly to S3 by declaring the necessary environment variables.
+To generate all tile images at once, append `tiles` to the `docker run` command. You can also upload them directly to S3 by declaring the necessary environment variables:
+* `MAPNIK_TILE_S3_BUCKET`: S3 bucket to upload tiles
+* `AWS_ACCESS_KEY_ID`: AWS access key ID
+* `AWS_SECRET_ACCESS_KEY`: AWS access key
+* `S3_FORCE_OVERWRITE`: controls how files are uploaded to S3; if set to "1" then all files will be uploaded, otherwise only the changed files will be uploaded. Whether the file has been changed is determined by the file size. It is recommended to set this flag whenever map style is modified, because if the only thing that is changed for a map tile is its color, then the file size is going to remain the same and the tile is not going to be uploaded
 
+
+Example: 
 ```bash
 $ docker run --tty \
     --name="tile-server" \
@@ -67,5 +73,6 @@ $ docker run --tty \
     --env MAPNIK_TILE_S3_BUCKET="my-s3-bucket-name" \
     --env AWS_ACCESS_KEY_ID="my-aws-access-key-id" \
     --env AWS_SECRET_ACCESS_KEY="my-aws-secret-access-key" \
+    --env S3_FORCE_OVERWRITE="1" \
     --publish="80:80" tile-server tiles
 ```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,12 +21,9 @@ fi
 # if 'tiles' is passed as a command to run, generate and publish tiles
 if [ "$1" == "tiles" ]; then
     sudo -E -u postgres /var/lib/postgresql/src/generate_tiles.py
-    if [ -n "${MAPNIK_TILE_S3_BUCKET}" ]; then
-        if [ "${S3_FORCE_OVERWRITE}" == "1" ]; then
-            cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/"
-        else
-            cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/" --size-only
-        fi
+    if [ -n "${MAPNIK_TILE_S3_BUCKET}" ]; then        
+        [[ "${S3_FORCE_OVERWRITE}" = "1" ]] && S3_ARGS= || S3_ARGS="--size-only"
+        cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/" ${S3_ARGS}
         echo "AWS S3 sync has completed successfully"
     fi
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,11 @@ fi
 if [ "$1" == "tiles" ]; then
     sudo -E -u postgres /var/lib/postgresql/src/generate_tiles.py
     if [ -n "${MAPNIK_TILE_S3_BUCKET}" ]; then
-        cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/" --size-only
+        if [ "${S3_FORCE_OVERWRITE}" == "1" ]; then
+            cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/"
+        else
+            cd /var/lib/mod_tile/ && aws s3 sync . "s3://${MAPNIK_TILE_S3_BUCKET}/osm_tiles/" --size-only
+        fi
         echo "AWS S3 sync has completed successfully"
     fi
 fi


### PR DESCRIPTION
Ticket: [Add flag for tile generation to upload all tiles regardless of their size](https://app.asana.com/0/810933294009540/1120172624141170)

Tested it locally (both with flag set and not set) and it works fine.  