### PR TITLE
Support tile copy operation in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN cd /usr/share/fonts/truetype/noto/ && \
 # generate tile scripts
 RUN apt-get -y install python-pip
 RUN pip install awscli
+RUN aws configure set default.s3.max_concurrent_requests 100
 COPY etc/generate_tiles.py /var/lib/postgresql/src/generate_tiles.py
 RUN chmod a+x /var/lib/postgresql/src/generate_tiles.py
 
@@ -75,7 +76,7 @@ RUN chmod a+x /var/lib/postgresql/src/generate_tiles.py
 RUN git clone https://github.com/tilemill-project/tilemill.git ~postgres/src/tilemill --depth 1
 RUN cd ~postgres/src/tilemill && npm install
 
-# install and configure styles 
+# install and configure styles
 RUN git clone https://github.com/jacobtoye/osm-bright.git /style --depth 1
 COPY etc/configure.py /style/configure.py
 COPY etc/osm-smartrak.osm2pgsql.mml /style/themes/osm-smartrak/osm-smartrak.osm2pgsql.mml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See below for different ways to run the container once built.
 
 ## Run Modes
 
-The container will load all map data automatically when started. There are three different modes for how to run it:
+The container will load all map data automatically when started. There are four different modes for how to run it:
 
 ### Renderd
 
@@ -61,11 +61,11 @@ $ docker run --tty \
 To generate all tile images at once, append `tiles` to the `docker run` command. You can also upload them directly to S3 by declaring the necessary environment variables:
 * `MAPNIK_TILE_S3_BUCKET`: S3 bucket to upload tiles
 * `AWS_ACCESS_KEY_ID`: AWS access key ID
-* `AWS_SECRET_ACCESS_KEY`: AWS access key
+* `AWS_SECRET_ACCESS_KEY`: AWS secret access key
 * `S3_FORCE_OVERWRITE`: controls how files are uploaded to S3; if set to "1" then all files will be uploaded, otherwise only the changed files will be uploaded. Whether the file has been changed is determined by the file size. It is recommended to set this flag whenever map style is modified, because if the only thing that is changed for a map tile is its color, then the file size is going to remain the same and the tile is not going to be uploaded
 
+Example:
 
-Example: 
 ```bash
 $ docker run --tty \
     --name="tile-server" \
@@ -77,28 +77,52 @@ $ docker run --tty \
     --publish="80:80" tile-server tiles
 ```
 
+### Copy Tiles Between S3 Buckets
+
+This container can also be used to copy tiles between S3 buckets. This operation makes use of the [AWS CLI](https://aws.amazon.com/cli/). Copying tiles does not depend on any of the other software included in the container, and could be run separately, but the functionality is included for the convenience of being able to run all tile-related operations in the same environment.
+
+To copy tiles, append `copy` to the `docker run` command, and declare the following environment variables:
+
+* `SOURCE_S3_PATH`: S3 bucket where the tiles are located
+* `DESTINATION_S3_PATH`: S3 bucket to copy tiles into
+* `AWS_ACCESS_KEY_ID`: AWS access key ID
+* `AWS_SECRET_ACCESS_KEY`: AWS secret access key
+
+Example:
+
+```bash
+$ docker run --tty \
+    --name="tile-server" \
+    --volume var-lib-postgres:/var/lib/postgresql \
+    --env SOURCE_S3_PATH="s3://my-s3-bucket-name/tile_path/" \
+    --env DESTINATION_S3_PATH="s3://other-s3-bucket-name/tile_path/" \
+    --env AWS_ACCESS_KEY_ID="my-aws-access-key-id" \
+    --env AWS_SECRET_ACCESS_KEY="my-aws-secret-access-key" \
+    --publish="80:80" tile-server copy
+```
+
 ### Publishing Tiles through AWS Batch
 
-To generate tiles for production usage we use [AWS Batch tool](https://aws.amazon.com/batch/), which allows to execute multiple similar jobs in parallel. In order to use AWS Batch, the first prerequisite is to push the docker image into AWS ECR Repository. Tile server image is already there so this step is only required in case if you have done any changes to the image (that is, changes to dockerfiles itself or to the files used by it). In order to push the image to ECR Repository, execute following commands: 
+To generate tiles for production usage we use [AWS Batch tool](https://aws.amazon.com/batch/), which allows to execute multiple similar jobs in parallel. In order to use AWS Batch, the first prerequisite is to push the docker image into AWS ECR Repository. Tile server image is already there so this step is only required in case if you have done any changes to the image (that is, changes to dockerfiles itself or to the files used by it). In order to push the image to ECR Repository, execute following commands:
 
 * `$(aws ecr get-login --no-include-email --region us-east-1)`: login to ECR
 * `docker build -t tile-server .`: build tile server docker image
 * `docker tag tile-server:latest 434035161053.dkr.ecr.us-east-1.amazonaws.com/tile-server:latest`: tag the image with the version called "latest"
 * `docker push 434035161053.dkr.ecr.us-east-1.amazonaws.com/tile-server:latest`: push (upload) docker image to the repository
 
-These steps should normally be set up to run in CI system, but at the time of writing this we don't have one, so they need to be executed manually. 
+These steps should normally be set up to run in CI system, but at the time of writing this we don't have one, so they need to be executed manually.
 
 
 
 Next step is to launch the AWS batch job(s) to generate the tiles through the uploaded docker image. Tiles are generated for a _service area_ defined in the source code: [generate_tiles.py](https://github.com/mbta/tile-server/blob/master/etc/generate_tiles.py#L195-L198). This area roughtly represents the area, which customers are believed to expect to see on the maps on the mbta.com website. If you change the area in the source code -- or do any other change there -- you need to rebuild the docker image and push it to the ECR repo (see above).
 
-The idea behind running the jobs in AWS batch is that we split the _service area_ into horizontal (East-West) stripes and generate tiles for each of those map stripes independently. Since there is no overlap, the execution can be parallelized and we can have as many parallel jobs as we see necessary. 
+The idea behind running the jobs in AWS batch is that we split the _service area_ into horizontal (East-West) stripes and generate tiles for each of those map stripes independently. Since there is no overlap, the execution can be parallelized and we can have as many parallel jobs as we see necessary.
 
 Important thing to note is that the service area only make sense if we have the map data for it. Currently we have map data for MA, RI and NH, so if you need service area to cover any other territories, you need to add map data first ([example PR](https://github.com/mbta/tile-server/pull/12/files)).
 
 In order to launch AWS Batch jobs, do the following:
 * Login into AWS Console and navigate to AWS Batch: https://console.aws.amazon.com/batch/
-* Go to "Job Definitions" section, click on the job name and then on the radio-button corresponding to the latest revision. 
+* Go to "Job Definitions" section, click on the job name and then on the radio-button corresponding to the latest revision.
   * Use `tile-generation-dev` for dev environment
   * Use `tile-generation-prod` for production environment
 * Click Actions -> Submit job
@@ -108,6 +132,6 @@ In order to launch AWS Batch jobs, do the following:
   * Specify **Array** as job type
   * Specify number of jobs to be run as parallel in Array Size field. If you don't know how many you need, put `8`. It took 5-6 hours for 8 jobs to generate the tiles for entire service area up to maximum zoom level (18) during previous tests
   * Navigate to **Environment variables** section and make sure that we `BATCH_JOB_COUNT` variable is set to correct values -- it should be equal to what you specified in Array Size field. Failure to set the right value here will result in either missing tiles or in overlap between the jobs (they are going to generate the same tiles)
-  * Click "Submit Job" and wait for jobs to run. You can also check CloudWatch logs, while the jobs are running. Links to those logs are available from the Jobs page. In addition, to CloudWatch logs we have slack notifications about jobs starting and completing in [#tile-server](https://mbtace.slack.com/messages/CHXHTUGMU) channel. 
+  * Click "Submit Job" and wait for jobs to run. You can also check CloudWatch logs, while the jobs are running. Links to those logs are available from the Jobs page. In addition, to CloudWatch logs we have slack notifications about jobs starting and completing in [#tile-server](https://mbtace.slack.com/messages/CHXHTUGMU) channel.
 
-These steps should also normally be set up to run in CI system, but at the time of writing this we don't have one, so they need to be executed manually. 
+These steps should also normally be set up to run in CI system, but at the time of writing this we don't have one, so they need to be executed manually.


### PR DESCRIPTION
https://app.asana.com/0/1113545750913664/1127168947428601

- Add a `copy` mode to the entrypoint script which runs `aws s3 sync` and then exits, bypassing all other functionality (including map data load)
- Configure the AWS CLI to raise the maximum number of concurrent requests from 10 to 100
- Remove trailing whitespace (my editor does this automatically, sorry for diffspam)

## Notes

In testing, the copy time was ~8 hours for ~3.78 million tiles. We could potentially reduce copy time by setting `max_concurrent_requests` to a higher value, as well as setting `max_queue_size` higher than the default of 1000. ([doc ref](https://docs.aws.amazon.com/cli/latest/topic/s3-config.html)) I'm not sure what the optimal values would be for the environment where the copy operation will run (i.e. inside a container on an m5d.large instance in AWS), nor am I sure whether it's worth taking the time to optimize, but I welcome ideas for how to test potential optimizations efficiently. 