### PR TITLE
Fixing the one-way arrows on the streets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,8 @@ RUN git clone https://github.com/jacobtoye/osm-bright.git /style --depth 1
 COPY etc/configure.py /style/configure.py
 COPY etc/osm-smartrak.osm2pgsql.mml /style/themes/osm-smartrak/osm-smartrak.osm2pgsql.mml
 COPY etc/palette.mss /style/themes/osm-smartrak/palette.mss
+# fix for https://github.com/mapbox/osm-bright/issues/109
+COPY etc/labels.mss /style/themes/osm-smartrak/labels.mss
 
 # fix permissions
 RUN chown -R postgres:postgres ~postgres/

--- a/etc/labels.mss
+++ b/etc/labels.mss
@@ -1,0 +1,548 @@
+/* LABELS.MSS CONTENTS:
+ * - place names
+ * - area labels
+ * - waterway labels 
+ */
+
+/* Font sets are defined in palette.mss */
+
+/* Mapnik does not yet support character-spacing adjustments for 
+   labels placed along a line. We can fake this using the replace()
+   function in the text-name parameter by replacing each character
+   with itself followed by one or more spaces. */
+
+/* ================================================================== */
+/* PLACE NAMES
+/* ================================================================== */
+
+#place::country[type='country'][zoom>3][zoom<=7] {
+  text-name:'[name]';
+  text-face-name:@sans_bold;
+  text-placement:point;
+  text-fill:@country_text;
+  text-halo-fill: @country_halo;
+  text-halo-radius: 1;
+  text-clip: false;
+  text-min-distance: 10;
+  [zoom=3] {
+    text-size:10 + @text_adjust;
+    text-wrap-width: 40;
+  }
+  [zoom=4] {
+    text-size:11 + @text_adjust;
+    text-wrap-width: 50;
+  }
+  [zoom>4] {
+    text-halo-radius: 2;
+  }
+  [zoom=5] {
+    text-size:13 + @text_adjust;
+    text-wrap-width: 50;
+    text-line-spacing: 1;
+  }
+  [zoom=6] {
+    text-size:13 + @text_adjust;
+    text-character-spacing: 1;
+    text-wrap-width: 80;
+    text-line-spacing: 2;
+  }
+  [zoom=7] {
+    text-size:14 + @text_adjust;
+    text-character-spacing: 2;
+  }
+}
+
+#place::state[type='state'][zoom>=5][zoom<=7] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-placement:point;
+  text-fill:@state_text;
+  text-halo-fill: @state_halo;
+  text-halo-radius: 1;
+  text-clip: false;
+  text-min-distance: 10;
+  [zoom=6] {
+    text-size:11 + @text_adjust;
+    text-wrap-width: 40;
+  }
+  [zoom=7] {
+    text-size:12 + @text_adjust;
+    text-wrap-width: 50;
+  }
+  [zoom>8] {
+    text-halo-radius: 2;
+  }
+  [zoom=8] {
+    text-size:11 + @text_adjust;
+    text-wrap-width: 50;
+    text-line-spacing: 1;
+  }
+  [zoom=9] {
+    text-size:12 + @text_adjust;
+    text-character-spacing: 1;
+    text-wrap-width: 80;
+    text-line-spacing: 2;
+  }
+  [zoom=10] {
+    text-size:14 + @text_adjust;
+    text-character-spacing: 2;
+  }
+}
+
+/* ---- Cities ------------------------------------------------------ */
+
+#place::city[type='city'][zoom>=5][zoom<=15] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-placement:point;
+  text-fill:@city_text;
+  text-halo-fill:@city_halo;
+  text-halo-radius:1;
+  text-clip: false;
+  text-min-distance: 10;
+  text-size: 12;
+  [zoom=7] {
+    text-size: 13;
+  }
+  [zoom=8] {
+    text-size: 14;
+  }
+  [zoom=9] {
+    text-size:14;
+    text-wrap-width: 60;
+  }
+  [zoom=10] {
+    text-size:15;
+    text-wrap-width: 70;
+  }
+  [zoom=11] {
+    text-size:15;
+    text-character-spacing: 1;
+    text-wrap-width: 80;
+  }
+  [zoom=12] {
+    text-size:15;
+    text-character-spacing: 1;
+    text-wrap-width: 100;
+  }
+  [zoom=13] {
+    text-size:15;
+    text-character-spacing: 2;
+    text-wrap-width: 200;
+    text-transform: uppercase;
+  }
+  [zoom=14] {
+    text-size:16;
+    text-character-spacing: 4;
+    text-wrap-width: 300;
+    text-transform: uppercase;
+  }
+  [zoom=15] {
+    text-size:17;
+    text-character-spacing: 6;
+    text-wrap-width: 400;
+    text-transform: uppercase;
+  }
+}
+
+/* ---- Towns ------------------------------------------------------- */
+
+#place::town[type='town'][zoom>=9][zoom<=17] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-placement:point;
+  text-fill:@town_text;
+  text-size:10;
+  text-halo-fill:@town_halo;
+  text-halo-radius:1;
+  text-wrap-width: 50;
+  text-clip: false;
+  text-min-distance: 20;
+  [zoom>=10] {
+    text-halo-radius:2;
+    text-size: 11;
+  }
+  [zoom>=11]{ text-size:12; }
+  [zoom>=12]{
+    text-size:13;
+    text-line-spacing: 1;
+  }
+  [zoom>=13]{
+    text-transform: uppercase;
+    text-character-spacing: 1;
+    text-line-spacing: 2;
+  }
+  [zoom>=14]{
+    text-size:14;
+    text-character-spacing: 2;
+    text-line-spacing: 3;
+  }
+  [zoom>=15]{
+    text-size:14;
+    text-character-spacing: 3;
+    text-line-spacing: 4;
+  }
+  [zoom>=15]{
+    text-size:15;
+    text-character-spacing: 4;
+    text-line-spacing: 5;
+  }
+  [zoom>=17]{
+    text-size:16;
+    text-character-spacing: 5;
+    text-line-spacing: 6;
+  }
+}
+
+/* ---- Other small places ------------------------------------------ */
+
+#place::small[type='village'][zoom>=12],
+#place::small[type='suburb'][zoom>=10],
+#place::small[type='hamlet'][zoom>=12] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-placement:point;
+  text-fill:@other_text;
+  text-size:11;
+  text-halo-fill:@other_halo;
+  text-halo-radius:1;
+  text-wrap-width: 30;
+  text-clip: false;
+  text-min-distance: 20;
+  [zoom>=14] {
+    text-size:12;
+    text-character-spacing: 1;
+    text-wrap-width: 40;
+    text-line-spacing: 1;
+  }
+  [zoom>=15] {
+    text-size:13;
+    text-halo-radius: 2;
+    text-transform: uppercase;
+    text-character-spacing: 1;
+    text-wrap-width: 60; 
+    text-line-spacing: 1;
+  }
+  [zoom>=16] {
+    text-character-spacing: 2;
+    text-wrap-width: 120;
+    text-line-spacing: 2;
+  } 
+  [zoom>=17] {
+    text-size:14; 
+    text-character-spacing: 3;
+    text-wrap-width: 160;
+    text-line-spacing: 4;
+  }
+  [zoom>=18] {
+    text-character-spacing: 4;
+    text-line-spacing: 6;
+  }
+}
+
+#place::small[type='locality'][zoom>=15] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-placement:point;
+  text-fill:@locality_text;
+  text-size:9;
+  text-halo-fill:@locality_halo;
+  text-halo-radius:1;
+  text-wrap-width: 30;
+  text-clip: false;
+  [zoom>=16] {
+    text-size:10;
+    text-wrap-width: 60;
+    text-line-spacing: 1;
+  }
+  [zoom>=17] {
+    text-size:11;
+    text-wrap-width: 120;
+    text-line-spacing: 2;
+  }
+  [zoom>=18] {
+    text-size:12;
+    text-character-spacing: 1;
+    text-line-spacing: 4;
+  }
+}
+
+
+// =====================================================================
+// AREA LABELS
+// =====================================================================
+
+#area_label {
+  // Bring in labels gradually as one zooms in, bases on polygon area
+  [zoom>=10][area>102400000],
+  [zoom>=11][area>25600000],
+  [zoom>=13][area>1600000],
+  [zoom>=14][area>320000],
+  [zoom>=15][area>80000],
+  [zoom>=16][area>20000],
+  [zoom>=17][area>5000],
+  [zoom>=18][area>=0] {
+    text-name: "[name]";
+    text-halo-radius: 1.5;
+    text-face-name:@sans;
+    text-size: 11;
+    text-wrap-width:30;
+    text-fill: rgba(0,0,0,0);
+    text-halo-fill: rgba(0,0,0,0);
+    text-clip: false;
+    // Specific style overrides for different types of areas:
+    [type='park'][zoom>=10] {
+      text-face-name: @sans;
+      text-fill: @park * 0.6;
+      text-halo-fill: lighten(@park, 10);
+    }
+    [type='golf_course'][zoom>=10] {
+      text-fill: @sports * 0.6;
+      text-halo-fill: lighten(@sports, 10);
+    }
+    [type='cemetery'][zoom>=10] {
+      text-fill: @cemetery * 0.6;
+      text-halo-fill: lighten(@cemetery, 10);
+    }
+    [type='hospital'][zoom>=10] {
+      text-fill: @hospital * 0.6;
+      text-halo-fill: lighten(@hospital, 10);
+    }
+    [type='college'][zoom>=10],
+    [type='school'][zoom>=10],
+    [type='university'][zoom>=10] {
+      text-fill: @school * 0.6;
+      text-halo-fill: lighten(@school, 10);
+    }
+    [type='water'][zoom>=10] {
+      text-fill: @water * 0.6;
+      text-halo-fill: lighten(@water, 10);
+    }
+  }
+  [zoom=15][area>1600000],
+  [zoom=16][area>80000],
+  [zoom=17][area>20000],
+  [zoom=18][area>5000] {
+    text-name: "[name]";
+    text-size: 13;
+    text-wrap-width: 60;
+    text-character-spacing: 1;
+    text-halo-radius: 2;
+  text-clip: false;
+  }
+  [zoom=16][area>1600000],
+  [zoom=17][area>80000],
+  [zoom=18][area>20000] {
+    text-size: 15;
+    text-character-spacing: 2;
+    text-wrap-width: 120;
+    text-clip: false;
+  }
+  [zoom>=17][area>1600000],
+  [zoom>=18][area>80000] {
+    text-size: 20;
+    text-character-spacing: 3;
+    text-wrap-width: 180;
+    text-clip: false;
+  }
+}
+   
+#poi[type='university'][zoom>=15],
+#poi[type='hospital'][zoom>=16],
+#poi[type='school'][zoom>=17],
+#poi[type='library'][zoom>=17] {
+  text-name:"[name]";
+  text-face-name:@sans;
+  text-size:10;
+  text-wrap-width:30;
+  text-fill: @poi_text;
+}
+
+
+/* ================================================================== */
+/* WATERWAY LABELS
+/* ================================================================== */
+
+#waterway_label[type='river'][zoom>=13],
+#waterway_label[type='canal'][zoom>=15],
+#waterway_label[type='stream'][zoom>=17] {
+  text-name: '[name]';
+  text-face-name: @sans;
+  text-fill: @water * 0.75;
+  text-halo-fill: fadeout(lighten(@water,5%),25%);
+  text-halo-radius: 1;
+  text-placement: line;
+  text-min-distance: 400;
+  text-size: 10;
+  text-clip: false;
+  text-avoid-edges: true; 
+  [type='river'][zoom>=12] {
+    text-size: 12;
+  }
+  [type='river'][zoom=14],
+  [type='canal'][zoom=16],
+  [type='stream'][zoom=18] {
+    text-name: "[name].replace('([\S\ ])','$1 ')";
+  }
+  [type='river'][zoom>=15],
+  [type='canal'][zoom=17] {
+    text-size: 14;
+    text-name: "[name].replace('([\S\ ])','$1 ')";
+  }
+  [type='river'][zoom>=17],
+  [type='canal'][zoom=18] {
+    text-size: 16;
+    text-name: "[name].replace('([\S\ ])','$1 ')";
+    text-spacing: 300;
+  }
+}
+
+/* ================================================================== */
+/* ROAD LABELS
+/* ================================================================== */
+
+#motorway_label[zoom>=11][zoom<=14][reflen<=8] {
+  shield-name: "[ref]";
+  shield-size: 9;
+  shield-face-name: @sans_bold;
+  shield-fill: #fff;
+  shield-file: url(img/shield-motorway-1.png);
+  [type='motorway'] {
+    [reflen=1] { shield-file: url(img/shield-motorway-1.png); }
+    [reflen=2] { shield-file: url(img/shield-motorway-2.png); }
+    [reflen=3] { shield-file: url(img/shield-motorway-3.png); }
+    [reflen=4] { shield-file: url(img/shield-motorway-4.png); }
+    [reflen=5] { shield-file: url(img/shield-motorway-5.png); }
+    [reflen=6] { shield-file: url(img/shield-motorway-6.png); }
+    [reflen=7] { shield-file: url(img/shield-motorway-7.png); }
+    [reflen=8] { shield-file: url(img/shield-motorway-8.png); }
+  }
+  [type='trunk'] {
+    [reflen=1] { shield-file: url(img/shield-trunk-1.png); }
+    [reflen=2] { shield-file: url(img/shield-trunk-2.png); }
+    [reflen=3] { shield-file: url(img/shield-trunk-3.png); }
+    [reflen=4] { shield-file: url(img/shield-trunk-4.png); }
+    [reflen=5] { shield-file: url(img/shield-trunk-5.png); }
+    [reflen=6] { shield-file: url(img/shield-trunk-6.png); }
+    [reflen=7] { shield-file: url(img/shield-trunk-7.png); }
+    [reflen=8] { shield-file: url(img/shield-trunk-8.png); }
+  }
+  [zoom=11] { shield-min-distance: 60; } //50
+  [zoom=12] { shield-min-distance: 80; } //60
+  [zoom=13] { shield-min-distance: 120; } //120
+  [zoom=14] { shield-min-distance: 180; }
+}
+
+#motorway_label[type='motorway'][zoom>9] {
+  text-name:"[name]";
+  text-face-name:@sans;
+  text-label-position-tolerance: 5;
+  text-placement:line;
+  text-fill:@motorway_text;
+  text-halo-fill:@motorway_halo;
+  text-halo-radius:1;
+  text-min-distance:60;
+  text-spacing: 100;
+  text-size:10;
+  text-clip: false;
+  text-min-padding: 5;
+  [zoom=11] { text-min-distance:70; }
+  [zoom=12] { text-min-distance:80; }
+  [zoom>=13] { text-min-distance:100; text-size:11; }
+  [zoom>=15] { text-size:12; }
+  [zoom>=17] { text-size:13; }
+}
+
+#motorway_label[type='trunk'][zoom>9],
+#mainroad_label[type='primary'][zoom>12] {
+  text-name:"[name]";
+  text-face-name:@sans;
+  text-label-position-tolerance: 5;
+  text-placement:line;
+  text-fill:@trunk_text;
+  text-halo-fill:@trunk_halo;
+  text-halo-radius:1;
+  text-min-distance:60;
+  text-spacing: 100;
+  text-size:10;
+  text-clip: false;
+  text-min-padding: 5;
+  [zoom=11] { text-min-distance:70; }
+  [zoom=12] { text-min-distance:80; }
+  [zoom>=13] { text-min-distance:100; text-size:11; }
+  [zoom>=15] { text-size:12; }
+  [zoom>=17] { text-size:13; }
+}
+
+#mainroad_label[type='secondary'][zoom>12] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-label-position-tolerance: 5;
+  text-placement:line;
+  text-fill:@secondary_text;
+  text-halo-fill:@secondary_halo;
+  text-halo-radius:1;
+  text-min-distance:60;
+  text-spacing: 100;
+  text-size:11;
+  text-clip: false;
+  text-min-padding: 5;
+  [zoom>=15] { text-size:12; }
+  [zoom>=17] { text-size:13; }
+}
+
+#mainroad_label[type='tertiary'][zoom>14],
+#minorroad_label[zoom>14] {
+  text-name:'[name]';
+  text-face-name:@sans;
+  text-label-position-tolerance: 5;
+  text-placement:line;
+  text-fill:@standard_text;
+  text-halo-fill:@standard_halo;
+  text-halo-radius:1;
+  text-min-distance:60;
+  text-spacing: 100;
+  text-size:11;
+  text-clip: false;
+  text-min-padding: 5;
+  [zoom>=15] { text-size:12; }
+  [zoom>=17] { text-size:13; }
+}
+
+/* ================================================================== */
+/* ONE-WAY ARROWS
+/* ================================================================== */
+
+#motorway_label[zoom>=16],
+#mainroad_label[zoom>=16],
+#minorroad_label[zoom>=16] {
+  [oneway = 'yes'],
+  [oneway='-1'] {
+     marker-placement:line;
+     marker-max-error: 0.5;
+     marker-spacing: 200;
+     marker-file: url(img/icon/oneway.svg);
+     [oneway='-1'] { marker-file: url(img/icon/oneway-reverse.svg); }
+     [zoom=16] { marker-transform: "scale(0.5)"; }
+     [zoom=17] { marker-transform: "scale(0.75)"; }
+  }
+}
+
+/* ================================================================== */
+/* FERRIES
+/* ================================================================== */
+
+#ferries[zoom>=15] {
+  text-name: '[name]';
+  text-face-name: @sans;
+  text-fill: @ferry_text;
+  text-halo-fill: @ferry_halo;
+  text-halo-radius: 1;
+  text-min-distance: 50;
+  text-placement: line;
+  text-size: 11;
+  text-clip: false;
+  text-avoid-edges: true; 
+}
+
+/* ****************************************************************** */


### PR DESCRIPTION
Ticket: [one-way arrows on two-way streets](https://app.asana.com/0/810933294009540/1140573234510306/f)

This PR applies patch similar to [this](https://github.com/mapbox/osm-bright/pull/111) to the styles we use. Now the arrows are displayed only for the roads specifically marked as one-way in OSM.

Before:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/45011335/69968485-84ba6e00-14e8-11ea-993d-4ba4cacbaa41.png">


After:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/45011335/69968558-a582c380-14e8-11ea-9e8a-6a88e772ba34.png">
