### PR TITLE
Get build working again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN /etc/init.d/postgresql start &&\
 
 #build osm2pgsql
 USER root
-RUN git clone git://github.com/openstreetmap/osm2pgsql.git ~postgres/src/osm2pgsql --depth 1
+RUN git clone https://github.com/openstreetmap/osm2pgsql.git ~postgres/src/osm2pgsql --depth 1
 RUN apt-get -y install make cmake g++ libboost-dev libboost-system-dev libboost-filesystem-dev libexpat1-dev\
-  zlib1g-dev libbz2-dev libpq-dev libgeos-dev libgeos++-dev libproj-dev lua5.2 liblua5.2-dev osmium-tool
+  zlib1g-dev libbz2-dev libpq-dev libgeos-dev libgeos++-dev libproj-dev lua5.2 liblua5.2-dev osmctools
 RUN cd ~postgres/src/osm2pgsql && mkdir build && cd build && cmake .. && make && make install
 
 #install Mapnik
@@ -63,7 +63,7 @@ COPY etc/apache2_kosmtik.conf /etc/apache2/sites-available/kosmtik.conf
 
 # additional fonts requred for pre-rendering
 RUN cd /usr/share/fonts/truetype/noto/ && \
-  wget https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoEmoji-Regular.ttf
+  wget https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf
 
 # generate tile scripts
 RUN apt-get -y install python-pip
@@ -73,8 +73,9 @@ COPY etc/generate_tiles.py /var/lib/postgresql/src/generate_tiles.py
 RUN chmod a+x /var/lib/postgresql/src/generate_tiles.py
 
 # install tilemill
-# RUN git clone https://github.com/tilemill-project/tilemill.git ~postgres/src/tilemill
-# RUN cd ~postgres/src/tilemill && git reset f04da9cfe42ddd22792031b9b1a6fe9470624bff --hard  && npm install
+RUN npm install -g npm
+RUN git clone https://github.com/tilemill-project/tilemill.git ~postgres/src/tilemill
+RUN cd ~postgres/src/tilemill && git reset f04da9cfe42ddd22792031b9b1a6fe9470624bff --hard && npm install
 
 # install and configure styles
 RUN git clone https://github.com/jacobtoye/osm-bright.git /style --depth 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get -y install autoconf apache2-dev libtool libxml2-dev libbz2-dev libge
   libproj-dev gdal-bin libmapnik-dev mapnik-utils python-mapnik sudo
 
 #build mod_tile and renderd
+# Newer commits in mod_tile remove the renderd.init file since the project is now in Debian / Ubuntu
+# official repositories, which provide their own init configuration, but those packages are only in
+# newer versions. Once we update this container to use 22.04, or another newer Ubuntu version, we can
+# install mod_tile that way and avoid having to build it ourselves entirely.
 RUN git clone https://github.com/openstreetmap/mod_tile.git ~postgres/src/mod_tile
 RUN cd ~postgres/src/mod_tile && git reset fd5988fc5877c51838ad96991d6e2912cfaf7d61 --hard && ./autogen.sh && ./configure && make && make install && make install-mod_tile && ldconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,11 @@ RUN apt-get -y install autoconf apache2-dev libtool libxml2-dev libbz2-dev libge
   libproj-dev gdal-bin libmapnik-dev mapnik-utils python-mapnik sudo
 
 #build mod_tile and renderd
-RUN git clone https://github.com/openstreetmap/mod_tile.git ~postgres/src/mod_tile --depth 1
-RUN cd ~postgres/src/mod_tile && ./autogen.sh && ./configure && make && make install && make install-mod_tile && ldconfig
+RUN git clone https://github.com/openstreetmap/mod_tile.git ~postgres/src/mod_tile
+RUN cd ~postgres/src/mod_tile && git reset fd5988fc5877c51838ad96991d6e2912cfaf7d61 --hard && ./autogen.sh && ./configure && make && make install && make install-mod_tile && ldconfig
 
 #build carto (map style configuration)
-RUN apt-get install -y npm nodejs
+RUN apt-get install -y npm nodejs node-gyp nodejs-dev libssl1.0-dev
 RUN npm install -g carto
 
 # install kosmtik
@@ -63,7 +63,7 @@ COPY etc/apache2_kosmtik.conf /etc/apache2/sites-available/kosmtik.conf
 
 # additional fonts requred for pre-rendering
 RUN cd /usr/share/fonts/truetype/noto/ && \
-  wget https://github.com/googlei18n/noto-emoji/raw/master/fonts/NotoEmoji-Regular.ttf
+  wget https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoEmoji-Regular.ttf
 
 # generate tile scripts
 RUN apt-get -y install python-pip
@@ -73,8 +73,8 @@ COPY etc/generate_tiles.py /var/lib/postgresql/src/generate_tiles.py
 RUN chmod a+x /var/lib/postgresql/src/generate_tiles.py
 
 # install tilemill
-RUN git clone https://github.com/tilemill-project/tilemill.git ~postgres/src/tilemill --depth 1
-RUN cd ~postgres/src/tilemill && npm install
+# RUN git clone https://github.com/tilemill-project/tilemill.git ~postgres/src/tilemill
+# RUN cd ~postgres/src/tilemill && git reset f04da9cfe42ddd22792031b9b1a6fe9470624bff --hard  && npm install
 
 # install and configure styles
 RUN git clone https://github.com/jacobtoye/osm-bright.git /style --depth 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,11 +72,6 @@ RUN aws configure set default.s3.max_concurrent_requests 100
 COPY etc/generate_tiles.py /var/lib/postgresql/src/generate_tiles.py
 RUN chmod a+x /var/lib/postgresql/src/generate_tiles.py
 
-# install tilemill
-RUN npm install -g npm
-RUN git clone https://github.com/tilemill-project/tilemill.git ~postgres/src/tilemill
-RUN cd ~postgres/src/tilemill && git reset f04da9cfe42ddd22792031b9b1a6fe9470624bff --hard && npm install
-
 # install and configure styles
 RUN git clone https://github.com/jacobtoye/osm-bright.git /style --depth 1
 COPY etc/configure.py /style/configure.py

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,7 @@ done
 if [ "$1" == "kosmtik" ]; then
     a2ensite kosmtik
     service apache2 restart
-    sudo -H -u postgres kosmtik serve /style/project.mml
+    sudo -H -u postgres kosmtik serve /style/output/OSMSmartrak/project.mml
 fi
 
 # if 'tiles' is passed as a command to run, generate and publish tiles

--- a/load_map_data.sh
+++ b/load_map_data.sh
@@ -27,11 +27,17 @@ if [ ! -f "${map_data_path}/merged.osm.pbf" ]; then
   done
 
   # merge map data
-  osmium merge -v --progress \
-    "${map_data_path}/massachusetts-latest.osm.pbf" \
-    "${map_data_path}/rhode-island-latest.osm.pbf" \
-    "${map_data_path}/new-hampshire-latest.osm.pbf" \
-    -o "${map_data_path}/merged.osm.pbf"
+  # `osmium merge` allows duplicates, which did not allow us to utilize osm2pgsql 
+  # in slim mode, so here we convert the files first to .o5m before merging
+  osmconvert "${map_data_path}/massachusetts-latest.osm.pbf" -o "${map_data_path}/massachusetts-latest.o5m"
+  osmconvert "${map_data_path}/rhode-island-latest.osm.pbf" -o "${map_data_path}/rhode-island-latest.o5m"
+  osmconvert "${map_data_path}/new-hampshire-latest.osm.pbf" -o "${map_data_path}/new-hampshire-latest.o5m"
+  # Merge o5m files into one pbf file:
+  osmconvert \
+    "${map_data_path}/massachusetts-latest.o5m" \
+    "${map_data_path}/rhode-island-latest.o5m" \
+    "${map_data_path}/new-hampshire-latest.o5m" \
+    -o="${map_data_path}/merged.osm.pbf"
 fi
 
 # download shapefiles

--- a/load_map_data.sh
+++ b/load_map_data.sh
@@ -29,9 +29,9 @@ if [ ! -f "${map_data_path}/merged.osm.pbf" ]; then
   # merge map data
   # `osmium merge` allows duplicates, which did not allow us to utilize osm2pgsql 
   # in slim mode, so here we convert the files first to .o5m before merging
-  osmconvert "${map_data_path}/massachusetts-latest.osm.pbf" -o "${map_data_path}/massachusetts-latest.o5m"
-  osmconvert "${map_data_path}/rhode-island-latest.osm.pbf" -o "${map_data_path}/rhode-island-latest.o5m"
-  osmconvert "${map_data_path}/new-hampshire-latest.osm.pbf" -o "${map_data_path}/new-hampshire-latest.o5m"
+  osmconvert "${map_data_path}/massachusetts-latest.osm.pbf" -o="${map_data_path}/massachusetts-latest.o5m"
+  osmconvert "${map_data_path}/rhode-island-latest.osm.pbf" -o="${map_data_path}/rhode-island-latest.o5m"
+  osmconvert "${map_data_path}/new-hampshire-latest.osm.pbf" -o="${map_data_path}/new-hampshire-latest.o5m"
   # Merge o5m files into one pbf file:
   osmconvert \
     "${map_data_path}/massachusetts-latest.o5m" \


### PR DESCRIPTION
Most of the major fixes here come from an old branch that @thecristen put together. I've added a single commit that fixes a few different little issues. The things I fixed are:

1. Removing Tilemill since it was causing a problem with the build and we don't seem to use it.
2. Correcting the arguments to `osmconvert` (it looks like it requires `-o="foo"` rather than `-o "foo"`, which is weird).
3. Correcting the path to the `project.mml` file in the command to invoke Kosmtik.

With these changes I'm able to build the image locally and run the three major operations (batch tile generate, live renderd server, Kosmtik) without major issues.