### PR TITLE
fix: fully tag Docker image so that push works

### DIFF
--- a/build_push.sh
+++ b/build_push.sh
@@ -8,7 +8,7 @@ app=tile-server
 tag=$1
 
 # build docker image and tag it with git hash and aws environment
-docker build -t $app:"$tag" -t $app:latest .
+docker build -t $app:"$tag" -t $app:latest -t "$DOCKER_SERVER"/$app:"$tag" -t "$DOCKER_SERVER"/$app:latest .
 
 # retrieve the `docker login` password from AWS ECR and use it
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "$DOCKER_SERVER"


### PR DESCRIPTION
Super quick fix, but `build_push.sh` wasn't working at first because it wasn't adding the corresponding tags for the remote repository, causing the push to not do anything (other than try to push the old version that was tagged properly).