### PR TITLE
feat(style/skate): water and green space color changes

### DIFF
--- a/etc/skate-style/base.mss
+++ b/etc/skate-style/base.mss
@@ -58,7 +58,7 @@
   [zoom=11] { line-width: 1.5; }
   [zoom>=12] { line-width: 2.0; }
 }
- 
+
 #landuse_overlays[type='wetland'][zoom>11] {
   [zoom>11][zoom<=14] { polygon-pattern-file:url(img/marsh-16.png); }
   [zoom>14] { polygon-pattern-file:url(img/marsh-32.png);}
@@ -115,7 +115,7 @@ Map { background-color: @water; }
     [zoom=14]{ line-width: 0.4; }
   }
 }
-  
+
 #waterway_high[zoom>=15] {
   line-color: @water;
   [type='river'],

--- a/etc/skate-style/labels.mss
+++ b/etc/skate-style/labels.mss
@@ -368,7 +368,7 @@
 #waterway_label[type='stream'][zoom>=17] {
   text-name: '[name]';
   text-face-name: @sans;
-  text-fill: @water * 0.75;
+  text-fill: @waterway_label;
   text-halo-fill: fadeout(lighten(@water,5%),25%);
   text-halo-radius: 1;
   text-placement: line;

--- a/etc/skate-style/labels.mss
+++ b/etc/skate-style/labels.mss
@@ -1,12 +1,12 @@
 /* LABELS.MSS CONTENTS:
  * - place names
  * - area labels
- * - waterway labels 
+ * - waterway labels
  */
 
 /* Font sets are defined in palette.mss */
 
-/* Mapnik does not yet support character-spacing adjustments for 
+/* Mapnik does not yet support character-spacing adjustments for
    labels placed along a line. We can fake this using the replace()
    function in the text-name parameter by replacing each character
    with itself followed by one or more spaces. */
@@ -220,16 +220,16 @@
     text-halo-radius: 2;
     text-transform: uppercase;
     text-character-spacing: 1;
-    text-wrap-width: 60; 
+    text-wrap-width: 60;
     text-line-spacing: 1;
   }
   [zoom>=16] {
     text-character-spacing: 2;
     text-wrap-width: 120;
     text-line-spacing: 2;
-  } 
+  }
   [zoom>=17] {
-    text-size:14; 
+    text-size:14;
     text-character-spacing: 3;
     text-wrap-width: 160;
     text-line-spacing: 4;
@@ -346,7 +346,7 @@
     text-clip: false;
   }
 }
-   
+
 #poi[type='university'][zoom>=15],
 #poi[type='hospital'][zoom>=16],
 #poi[type='school'][zoom>=17],
@@ -375,7 +375,7 @@
   text-min-distance: 400;
   text-size: 10;
   text-clip: false;
-  text-avoid-edges: true; 
+  text-avoid-edges: true;
   [type='river'][zoom>=12] {
     text-size: 12;
   }
@@ -543,7 +543,7 @@
   text-placement: line;
   text-size: 11;
   text-clip: false;
-  text-avoid-edges: true; 
+  text-avoid-edges: true;
 }
 
 /* ****************************************************************** */

--- a/etc/skate-style/labels.mss
+++ b/etc/skate-style/labels.mss
@@ -294,25 +294,25 @@
     [type='park'][zoom>=10] {
       text-face-name: @sans;
       text-fill: @park * 0.6;
-      text-halo-fill: lighten(@park, 10);
+      text-halo-fill: @greenspace_halo;
     }
     [type='golf_course'][zoom>=10] {
       text-fill: @sports * 0.6;
-      text-halo-fill: lighten(@sports, 10);
+      text-halo-fill: @greenspace_halo;
     }
     [type='cemetery'][zoom>=10] {
       text-fill: @cemetery * 0.6;
-      text-halo-fill: lighten(@cemetery, 10);
+      text-halo-fill: @greenspace_halo;
     }
     [type='hospital'][zoom>=10] {
       text-fill: @hospital * 0.6;
-      text-halo-fill: lighten(@hospital, 10);
+      text-halo-fill: @greenspace_halo;
     }
     [type='college'][zoom>=10],
     [type='school'][zoom>=10],
     [type='university'][zoom>=10] {
       text-fill: @school * 0.6;
-      text-halo-fill: lighten(@school, 10);
+      text-halo-fill: @greenspace_halo;
     }
     [type='water'][zoom>=10] {
       text-fill: @water * 0.6;

--- a/etc/skate-style/palette.mss
+++ b/etc/skate-style/palette.mss
@@ -41,7 +41,7 @@ Map { font-directory: url(./fonts); }
 
 @land:              @background_grey;
 @land_low:          @background_grey;
-@water:             #c8c9e5;
+@water:             #b6bee7;
 @grass:             #c9e2c1;
 @beach:             #ffeec7;
 @park:              #c9e2c1;

--- a/etc/skate-style/palette.mss
+++ b/etc/skate-style/palette.mss
@@ -43,11 +43,11 @@ Map { font-directory: url(./fonts); }
 @land_low:          @background_grey;
 @water:             #c8c9e5;
 @grass:             #c9e2c1;
-@beach:             #FFEEC7;
+@beach:             #ffeec7;
 @park:              #c9e2c1;
 @cemetery:          #c9e2c1;
 @wooded:            #c9e2c1;
-@agriculture:       #F2E8B6;
+@agriculture:       #f2e8b6;
 
 @building:          @background_grey;
 @building_line:     #dbdde1;

--- a/etc/skate-style/palette.mss
+++ b/etc/skate-style/palette.mss
@@ -39,14 +39,16 @@ Map { font-directory: url(./fonts); }
 
 @background_grey:   #f4f4f5;
 
+@greenspace:        #b1deaf;
+
 @land:              @background_grey;
 @land_low:          @background_grey;
 @water:             #b6bee7;
-@grass:             #c9e2c1;
+@grass:             @greenspace;
 @beach:             #ffeec7;
-@park:              #c9e2c1;
-@cemetery:          #c9e2c1;
-@wooded:            #c9e2c1;
+@park:              @greenspace;
+@cemetery:          @greenspace;
+@wooded:            @greenspace;
 @agriculture:       #f2e8b6;
 
 @building:          @background_grey;
@@ -54,7 +56,7 @@ Map { font-directory: url(./fonts); }
 @building_case:     #d3d1c8;
 @hospital:          #ebe3da;
 @school:            @background_grey;
-@sports:            #c9e2c1;
+@sports:            @greenspace;
 
 @residential:       @background_grey;
 @commercial:        @background_grey;

--- a/etc/skate-style/palette.mss
+++ b/etc/skate-style/palette.mss
@@ -40,6 +40,7 @@ Map { font-directory: url(./fonts); }
 @background_grey:   #f4f4f5;
 
 @greenspace:        #b1deaf;
+@waterway_label:    #2c45c6;
 
 @land:              @background_grey;
 @land_low:          @background_grey;

--- a/etc/skate-style/palette.mss
+++ b/etc/skate-style/palette.mss
@@ -132,6 +132,9 @@ Map { font-directory: url(./fonts); }
    at once or override each individually. */
 @place_halo:        fadeout(#fff,34%);
 
+@halo_white:        @place_halo;
+@greenspace_halo:   @halo_white;
+
 @country_text:      #222;
 @country_halo:      @place_halo;
 

--- a/etc/skate-style/palette.mss
+++ b/etc/skate-style/palette.mss
@@ -40,7 +40,7 @@ Map { font-directory: url(./fonts); }
 @background_grey:   #f4f4f5;
 
 @land:              @background_grey;
-@land_low: 		     @background_grey;
+@land_low:          @background_grey;
 @water:             #c8c9e5;
 @grass:             #c9e2c1;
 @beach:             #FFEEC7;


### PR DESCRIPTION
Asana Ticket: https://app.asana.com/0/1203014709808707/1203180633835790/f

# Summary
- greenspace color #b1deaf
- greenspace use white halo
- water color #b6bee7
- water labels use #2c45c6

Make style more consistent and clean up trailing whitespace.

## Links
The first three commits are whitespace and code style fixes, browsing the last 4 commits will narrow down the scope of what actually changed.
https://github.com/mbta/tile-server/pull/25/files/16661ad191f3e4c2c5eb39d484ed417c0a98c70b..0cc592a1a5da6290090ba9c5de2a99f25af55578