### PR TITLE
fix(retry job): Don't start env variable with AWS_BATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The generate_tiles.py script uses the following environment variables to determi
 Sometimes, a subset of the parallel child jobs may fail. to retry a specific child job, set the following environment variables (`AWS_BATCH_JOB_ARRAY_INDEX` will be ignored).
 
 - `BATCH_JOB_COUNT`: The `BATCH_JOB_COUNT` value of the job to retry. Unlike for regular job runs, this does not need to match "Array Size". "Array Size" should not be specified.
-- `AWS_BATCH_JOB_ARRAY_INDEX_OVERRIDE`: The `AWS_BATCH_JOB_ARRAY_INDEX` of the job to retry
+- `RETRY_AWS_BATCH_JOB_ARRAY_INDEX`: The `AWS_BATCH_JOB_ARRAY_INDEX` of the job to retry
 
 ### Copy Tiles Between S3 Buckets
 

--- a/etc/generate_tiles.py
+++ b/etc/generate_tiles.py
@@ -231,9 +231,9 @@ if __name__ == "__main__":
         tile_dir = tile_dir + '/'
 
     try: 
-        if 'AWS_BATCH_JOB_ARRAY_INDEX_OVERRIDE' in os.environ:
+        if 'RETRY_AWS_BATCH_JOB_ARRAY_INDEX' in os.environ:
             print "Using retry job configuration"
-            current_thread = int(os.environ['AWS_BATCH_JOB_ARRAY_INDEX_OVERRIDE'])
+            current_thread = int(os.environ['RETRY_AWS_BATCH_JOB_ARRAY_INDEX'])
         else:
             current_thread = int(os.environ['AWS_BATCH_JOB_ARRAY_INDEX'])
 


### PR DESCRIPTION
Oops - missed this in [the docs](https://docs.aws.amazon.com/batch/latest/userguide/job_env_vars.html):

> All variables that AWS Batch set start with the AWS_BATCH_ prefix. This is a protected environment variable prefix. You can't use this prefix for your own variables in job definitions or overrides.


![image](https://user-images.githubusercontent.com/31781298/226425527-67de8561-83c7-4835-b37b-da4b896a358b.png)
