### PR TITLE
fix(skate-style): Better handle conflicting landmarks across tile edges

### DIFF
--- a/etc/skate-style/project.osm2pgsql.mml
+++ b/etc/skate-style/project.osm2pgsql.mml
@@ -475,7 +475,7 @@
         "key_field": "", 
         "project": "foss4g-2011", 
         "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
-        "table": "( SELECT amenity AS type, name, way_area AS area,\n    ST_PointOnSurface(way) AS way\n  FROM planet_osm_polygon\n  WHERE name IS NOT NULL\n    AND way && !bbox!\n    AND ST_IsValid(way)\n UNION ALL\n\n  SELECT amenity AS type, name, 0 AS area, way\n FROM planet_osm_point\n  WHERE name IS NOT NULL\n ORDER BY area DESC\n) AS data", 
+        "table": "( SELECT osm_id, amenity AS type, name, way_area AS area,\n    ST_PointOnSurface(way) AS way\n  FROM planet_osm_polygon\n  WHERE name IS NOT NULL\n    AND way && !bbox!\n    AND ST_IsValid(way)\n UNION ALL\n\n  SELECT osm_id, amenity AS type, name, 0 AS area, way\n FROM planet_osm_point\n  WHERE name IS NOT NULL\n ORDER BY area DESC, osm_id\n) AS data", 
         "type": "postgis"
       }, 
       "class": "", 


### PR DESCRIPTION
Part of https://app.asana.com/0/1148853526253437/1204073120343847/f

Investigating a separate ticket, @firestack noticed a police station & library colliding across a border, resulting in both being only partially rendered.
![image](https://user-images.githubusercontent.com/31781298/227596305-581b3084-2b6e-40ef-ae7e-f2fae3c041b8.png)

Looking at existing github issues for cut off tiles, I found [this](https://github.com/mapnik/mapnik/issues/3039#issuecomment-134177573) comment: 

> I would try to sort those roads by id or something. I think that some undetermined collision is going on.

This was consistent with something that I experienced locally, where upon reloading the styles without making any changes, different combinations of the police & library would be cut off across the edge. 
I added sorting by `osm_id`, which seemed to at least make the cutoff behavior consistent across meta tiles and across multiple rerenders. 

I am uncertain about exactly how this will render when we run a job; there are still inconsistencies still when rendering with kosmtik vs renderd. 
Using both tools, the State Police Government Center is rendered fully without any conflicting library, which is the main goal of this PR.

However, there is a cluster of 3 libraries across a meta tile edge that renders differently: 
**Kosmtik**
* one library still has a partially visible label (unexpected + undesired) 
![image](https://user-images.githubusercontent.com/31781298/227595959-da214a9a-5da2-4c05-b909-e2cfd3d57d06.png)

**Renderd** 
* that library label is entirely omitted (expected + desired, because the icons are drawn first, and the label would conflict with existing the icon for the Boston Athenaeum Library)
![image](https://user-images.githubusercontent.com/31781298/227596232-ef9400de-072a-4003-9f73-00d40c41a298.png)


I'm not sure if either tool exactly matches what we should expect to see when running a build job, but am interested to run with this change this and see what we end up with!