### PR TITLE
fix and schedule docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  schedule:
+    - cron: "38 17 * * 2"
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN /etc/init.d/postgresql start &&\
 
 #build osm2pgsql
 USER root
-RUN git clone https://github.com/openstreetmap/osm2pgsql.git ~postgres/src/osm2pgsql --depth 1
+RUN git clone https://github.com/openstreetmap/osm2pgsql.git ~postgres/src/osm2pgsql --depth 1 --branch 1.8.1
 RUN apt-get -y install make cmake g++ libboost-dev libboost-system-dev libboost-filesystem-dev libexpat1-dev\
   zlib1g-dev libbz2-dev libpq-dev libgeos-dev libgeos++-dev libproj-dev lua5.2 liblua5.2-dev osmctools
 RUN cd ~postgres/src/osm2pgsql && mkdir build && cd build && cmake .. && make && make install


### PR DESCRIPTION
Since April, osm2pgsql has released a few major versions that break compatibility with this setup. The new dependency that was breaking things is actually packaged in Ubuntu 18.04, so I tried installing it and leaving the clone on the main branch, but that led to other errors I didn't have the energy to chase down.

This Dockerfile is fairly brittle and not very actively maintained, so we didn't notice this for a while. It'd be nice to have at least some heads up that things are broken. (As it stands, I think this would email me if the scheduled build fails, since I'd be the last person to touch the cron schedule, which is [apparently how that works](https://docs.github.com/en/enterprise-cloud@latest/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs). If someone wants to change the minute to a different arbitrary value that isn't the top of the hour, that should give them those notifications instead.)

I am not familiar enough with this project to be confident that the built container actually works correctly; someone else will need to verify that.